### PR TITLE
Replace charitable by generous

### DIFF
--- a/RICE/events/RICE_yorkshire_events.txt
+++ b/RICE/events/RICE_yorkshire_events.txt
@@ -2027,7 +2027,7 @@ yorkshire.0105 = {
 		base = 1
 		modifier = {
 			add = 0.2
-			has_trait = charitable
+			has_trait = generous
 		}
 		modifier = {
 			add = -0.2
@@ -2176,7 +2176,7 @@ yorkshire.0107 = {
 		}
 		modifier = {
 			add = 0.2
-			has_trait = charitable
+			has_trait = generous
 		}
 		modifier = {
 			add = -0.2
@@ -2239,7 +2239,7 @@ yorkshire.0108 = {
 		}
 		modifier = {
 			add = 0.2
-			has_trait = charitable
+			has_trait = generous
 		}
 		modifier = {
 			add = -0.2
@@ -2297,7 +2297,7 @@ yorkshire.0109 = {
 		}
 		modifier = {
 			add = -0.2
-			has_trait = charitable
+			has_trait = generous
 		}
 		modifier = {
 			add = 0.2


### PR DESCRIPTION
Charitable doesn't exist so I replace it by generous which is the opposite of greedy.

The logs : 

```
[12:42:01][jomini_script_system.cpp:169]: Script system error!
  Error: has_trait trigger [ Cannot find charitable in trait database ]
  Script location: file: events/RICE_yorkshire_events.txt line: 2030
[12:42:01][jomini_script_system.cpp:169]: Script system error!
  Error: has_trait trigger [ Cannot find charitable in trait database ]
  Script location: file: events/RICE_yorkshire_events.txt line: 2179
[12:42:01][jomini_script_system.cpp:169]: Script system error!
  Error: has_trait trigger [ Cannot find charitable in trait database ]
  Script location: file: events/RICE_yorkshire_events.txt line: 2242
[12:42:01][jomini_script_system.cpp:169]: Script system error!
  Error: has_trait trigger [ Cannot find charitable in trait database ]
  Script location: file: events/RICE_yorkshire_events.txt line: 2300
```
