### PR TITLE
Remove backslash

### DIFF
--- a/RICE/localization/french/rice_chios_l_french.yml
+++ b/RICE/localization/french/rice_chios_l_french.yml
@@ -1,7 +1,7 @@
 ﻿l_french:
 
  RICE_found_mastic_village_context_tooltip:0 "#emphasis Historical Context:#! Le mastic a été une source majeur de profit pour l'île de Chios depuis l'antiquité. Pendant des siècles Empereurs Romains comme Sultans Ottomans ont essayé de monopoliser cette industrie, et développer les villages de Mastic était une partie de cette stratégie."
- RICE_erect_homer_monument_context_tooltip:0 "#emphasis Historical Context:#! \ Bien que l'on puisse douter de l'existance de l'ancien poète Homère, Chios était considérée comme son lieu de naissance durant cette période historique."
+ RICE_erect_homer_monument_context_tooltip:0 "#emphasis Historical Context:#! Bien que l'on puisse douter de l'existance de l'ancien poète Homère, Chios était considérée comme son lieu de naissance durant cette période historique."
  RICE_attend_mostra_of_thymiana_context_tooltip:0 "#emphasis Historical Context:#! It is unknown if and when the legendary battle against the pirates in Thymiana occurred, though if it did it would have been sometime in the late medieval or early Renaissance period. Either way, the Mostra of Thymiana in real life has been held for many centuries since then."
  
  RICE_chios_mastic_groves:0 "Bosquet de lentisques. (Arbre à Mastic)"


### PR DESCRIPTION
Backslash was useless and write an error message in logs : 
`[localization_reader.cpp:243]: Illegal break character (utf32=32) at line 4 and column 80 in localization/french/rice_chios_l_french.yml`