### PR TITLE
Fix typo in Mercenaries

### DIFF
--- a/RICE/localization/english/rice_normandy_l_english.yml
+++ b/RICE/localization/english/rice_normandy_l_english.yml
@@ -39,7 +39,7 @@
  game_concept_RICE_normandy_settles:1 "Settles"
  game_concept_RICE_normandy_courtiers:1 "Courtiers"
  game_concept_RICE_normandy_colonists:1 "Colonists"
- game_concept_RICE_normandy_mercenaries:1 "Merencaries"
+ game_concept_RICE_normandy_mercenaries:1 "Mercenaries"
  game_concept_RICE_normandy_traders:1 "Traders"
  game_concept_RICE_normandy_scholars:1 "Scholars"
  game_concept_RICE_normandy_settlers:1 "Norse and Norman Settlers"


### PR DESCRIPTION
The 'c' was misplaced