### PR TITLE
Correcting a typo RICE_sea_dynasties_l_english.yml

### DIFF
--- a/RICE/localization/replace/english/RICE_sea_dynasties_l_english.yml
+++ b/RICE/localization/replace/english/RICE_sea_dynasties_l_english.yml
@@ -3067,7 +3067,7 @@
   dynn_Sho:0 "Sho"
   dynn_Shoni:0 "Shōni"
   dynn_Shresta:0 "Shresta"
-  dynn_Shrestapura:0 "Shresta"
+  dynn_Shrestapura:0 "Shrestapura"
   dynn_Shu:0 "Shu"
   dynn_Shu_Ha:0 "Shu Ha"
   dynn_Shu_Ha_Sse_Nge:0 "Shu Ha Sse Nge"


### PR DESCRIPTION
dynn_Shrestapura:0 "Shresta" > dynn_Shrestapura:0 "Shrestapura"