### PR TITLE
Fix activities for LAAMPs

### DIFF
--- a/RICE/common/activities/activity_types/RICE_bamian_buddhas_non_buddhist_visit.txt
+++ b/RICE/common/activities/activity_types/RICE_bamian_buddhas_non_buddhist_visit.txt
@@ -23,14 +23,28 @@
 
 	can_start = {
 		NOT = { religion = religion:buddhism_religion }
-		OR = {
-			title:c_bamian = {
-				squared_distance = {
-					target = root.capital_province
-					value <= squared_distance_medium
+		trigger_if = {
+			limit = { is_landless_adventurer = no }
+			OR = {
+				custom_description = {
+					text = RICE_bamian_close_to_bamian_req
+					title:c_bamian = {
+						squared_distance = {
+							target = root.capital_province
+							value <= squared_distance_medium
+						}
+					}
+				}
+				has_title = title:c_bamian
+			}
+		}
+		trigger_else = {
+			custom_description = {
+				text = RICE_bamian_in_bamian_req
+				domicile.domicile_location ?= {
+					this = title:b_bamian.title_province
 				}
 			}
-			has_title = title:c_bamian
 		}
 	}
 

--- a/RICE/localization/english/rice_bamian_l_english.yml
+++ b/RICE/localization/english/rice_bamian_l_english.yml
@@ -83,6 +83,8 @@
  RICE_bamian_offerings_both_log_title:0 "Extra Offerings to the Both $c_bamian$ Buddha Statues"
  RICE_bamian_offerings_both_log:0 "[CHARACTER.GetShortUIName|U] made extra offerings to both $c_bamian$ Buddha Statues"
  TRAVEL_NAME_FOR_activity_RICE_bamian_pilgrimage:0 "[Character.GetFirstNamePossessiveNoTooltip] $activity_RICE_bamian_pilgrimage$"
+ RICE_bamian_close_to_bamian_req:0 "Your [capital|E] is close to [GetTitleByKey('c_bamian').GetNameNoTier]"
+ RICE_bamian_in_bamian_req:0 "Your [camp|E] is in [GetTitleByKey('c_bamian').GetNameNoTier]"
 
  # Modifiers
  RICE_bamian_siman_tov_modifier: "Jewish Notable of Bamiyan"


### PR DESCRIPTION
Fixes #211 

Check the domicile location if root is a LAAMP in `can_start`, with appropriate descriptions for both landless and landed.

The fix is currently just for the "Trip to the Statues of Bamian" activity. If you ok with this approach, I could extend this to fix all other activities that would be affected by this issue (all that require a particular location and allow LAAMPs as hosts).

I tested that the fix works - the activity is still shown but can't be started, and the custom description is shown properly. I also tested that starting the activity if your camp is in Bamian works without issues.

Screenshots:
![2025_07_18_1](https://github.com/user-attachments/assets/3680f329-a44f-45b7-987a-90acd10e686d)
![2025_07_18_2](https://github.com/user-attachments/assets/902f336c-7d29-4dd4-bc8b-dbadcb769835)
