### PR TITLE
Fix startup error about inconsistent effect scopes

### DIFF
--- a/RICE/common/casus_belli_types/RICE_normandy_norman_adventurer_conquest.txt
+++ b/RICE/common/casus_belli_types/RICE_normandy_norman_adventurer_conquest.txt
@@ -902,9 +902,13 @@ RICE_norman_adventure_cb = {
 						type = swear_fealty
 						save_scope_as = change
 					}
-					change_liege = {
-						liege = scope:original_liege
-						change = scope:change
+					hidden_effect = {
+						scope:local_warlord = {
+							change_liege = {
+								liege = scope:original_liege
+								change = scope:change
+							}
+						}
 					}
 					resolve_title_and_vassal_change = scope:change
 				}
@@ -973,10 +977,14 @@ RICE_norman_adventure_cb = {
 							type = swear_fealty
 							save_scope_as = change
 						}
-						change_liege = {
-							liege = scope:original_liege
-							change = scope:change
-						}
+						hidden_effect = {
+							scope:local_warlord = {
+								change_liege = {
+									liege = scope:original_liege
+									change = scope:change
+								}
+							}
+						}						
 						resolve_title_and_vassal_change = scope:change
 					}
 					else = {


### PR DESCRIPTION
Fix the following error from RICE on startup:
```
Inconsistent effect scopes (landed_title vs. character) infile: common/casus_belli_types/RICE_normandy_norman_adventurer_conquest.txt
```
The issue is that `change_liege` requires a character scope, not a landed title. From the rest of the script, it looks like the correct character is `scope:local_warlord`.