### PR TITLE
Roman Empire Decision properly adds Alodia to Aegyptus

### DIFF
--- a/RICE/common/on_action/RICE_romanempire_on_actions.txt
+++ b/RICE/common/on_action/RICE_romanempire_on_actions.txt
@@ -1,0 +1,79 @@
+on_title_gain = {
+	on_actions = {
+		RICE_restoreromanempire_on_gain
+	}
+}
+
+RICE_restoreromanempire_on_gain = {
+	trigger = {
+		scope:title = title:h_roman_empire
+	}
+
+	effect = {	
+		if = {
+			limit = {
+				scope:title = title:h_roman_empire
+				NOT = {
+					scope:title = {
+					has_variable = RICE_romanempiredejure_processed
+					}
+				}
+			}
+
+			#Set the variable so this won't happen again
+			scope:title = {
+				set_variable = {
+					name = RICE_romanempiredejure_processed
+					value = yes
+				}
+			}
+
+			# Check all sub-realm titles within realm
+			# Aegyptus
+			every_sub_realm_title = {
+				limit = {
+					tier = tier_kingdom
+					NOR = { #Ignore if it's already somehow in any of the Roman Empire's sub-empires
+						de_jure_liege = title:e_illyria
+						de_jure_liege = title:e_macedonia
+						de_jure_liege = title:e_anatolia
+						de_jure_liege = title:e_oriens
+						de_jure_liege = title:e_aegyptus
+						de_jure_liege = title:e_africa
+					}
+				}
+				if = {
+					limit = {
+						exists = title:e_aegyptus
+						OR = {
+							#Egypt, Blemmyia, Nubia, and Abyssinia are all handled by the base game at this point
+							title:k_alodia    ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_aegyptus
+				}
+			}
+			# Check all De-Jure titles of Byzantium
+			title:e_byzantium = {
+				if = { 
+					limit = {
+						OR = {
+							NOT = { exists = holder }
+							holder ?= root
+						}
+					}
+					every_in_de_jure_hierarchy = {
+						limit = {
+							exists = title:e_aegyptus
+							tier = tier_kingdom
+							OR = {
+								title:k_alodia    ?= this
+							}
+						}
+						set_de_jure_liege_title = title:e_aegyptus
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
When restoring the Roman Empire, Any owned kingdom titles and dejure kingdoms under the Byzantine Empire get rolled into new empire titles named after the Roman name for places.

The Nubia Flavor Pack added the Kingdom of Alodia, but the vanilla effect adds titles by-name so it had a gap there in the Empire title "Aegyptus"

This PR makes an on_gain effect that checks if the title is the Roman Empire and then accounts for Alodia. There is a variable so if someone inherits it or otherwise gains it, it will not happen again.

![1158310_994](https://github.com/user-attachments/assets/47c3607b-12c4-4750-bdfb-f30ebba28df5)
![1158310_993](https://github.com/user-attachments/assets/479d8ab1-9163-43db-99af-f5199f901e9e)

Oddly, in the vanilla game Aegyptus does not take all the kingdom titles of the Abyssinian Empire and leaves it with two kingdom titles. I left them out as that is the behavior in vanilla.
