### PR TITLE
chore(Siwa): removed historical context for the Maintain Kharshif Str…

### DIFF
--- a/RICE/common/decisions/RICE_siwa_decisions.txt
+++ b/RICE/common/decisions/RICE_siwa_decisions.txt
@@ -40,13 +40,6 @@ RICE_siwa_kharshif_structures_decision = {
 			RICE_siwa_kharshif_structures_decision_effect = yes
 		}
 
-		if = {
-			limit = {
-				has_game_rule = RICE_historical_context_on
-			}
-			custom_tooltip = RICE_siwa_kharshif_structures_decision_context_tooltip
-		}
-
 		trigger_event = {
 			id = siwa.0001
 		}

--- a/RICE/localization/english/rice_siwa_l_english.yml
+++ b/RICE/localization/english/rice_siwa_l_english.yml
@@ -68,7 +68,6 @@
  RICE_siwa_kharshif_structures_decision_desc:0 "Time and time again, the effectiveness of [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] as a construction material is proven. However, these traditional building materials from [GetTitleByKey('b_siwa').GetNameNoTier] could always use some maintenance."
  RICE_siwa_kharshif_structures_decision_effect_tooltip_1:1 "xxxxx"
  RICE_siwa_kharshif_structures_decision_confirm:0 "Let's get to work!"
- RICE_siwa_kharshif_structures_decision_context_tooltip:0 "#emphasis Historical Context:#! $KHARSHIF_GLOSS$"
  RICE_siwa_kharshif_modifier:0 "Maintaining Kharshif Structures"
  RICE_siwa_kharshif_modifier_desc:0 "Local rulers have dedicated resources to ensure that the [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] blocks of Siwa Oasis' structures will continue to be viable for a long, long time."
 

--- a/RICE/localization/german/rice_siwa_l_german.yml
+++ b/RICE/localization/german/rice_siwa_l_german.yml
@@ -68,7 +68,6 @@
  RICE_siwa_kharshif_structures_decision_desc:0 "Time and time again, the effectiveness of [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] as a construction material is proven. However, these traditional building materials from [GetTitleByKey('b_siwa').GetNameNoTier] could always use some maintenance."
  RICE_siwa_kharshif_structures_decision_effect_tooltip_1:1 "xxxxx"
  RICE_siwa_kharshif_structures_decision_confirm:0 "Let's get to work!"
- RICE_siwa_kharshif_structures_decision_context_tooltip:0 "#emphasis Historical Context:#! $KHARSHIF_GLOSS$"
  RICE_siwa_kharshif_modifier:0 "Maintaining Kharshif Structures"
  RICE_siwa_kharshif_modifier_desc:0 "Local rulers have dedicated resources to ensure that the [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] blocks of Siwa Oasis' structures will continue to be viable for a long, long time."
 

--- a/RICE/localization/japanese/rice_siwa_l_japanese.yml
+++ b/RICE/localization/japanese/rice_siwa_l_japanese.yml
@@ -68,7 +68,6 @@
  RICE_siwa_kharshif_structures_decision_desc:0 "Time and time again, the effectiveness of [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] as a construction material is proven. However, these traditional building materials from [GetTitleByKey('b_siwa').GetNameNoTier] could always use some maintenance."
  RICE_siwa_kharshif_structures_decision_effect_tooltip_1:1 "xxxxx"
  RICE_siwa_kharshif_structures_decision_confirm:0 "Let's get to work!"
- RICE_siwa_kharshif_structures_decision_context_tooltip:0 "#emphasis Historical Context:#! $KHARSHIF_GLOSS$"
  RICE_siwa_kharshif_modifier:0 "Maintaining Kharshif Structures"
  RICE_siwa_kharshif_modifier_desc:0 "Local rulers have dedicated resources to ensure that the [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] blocks of Siwa Oasis' structures will continue to be viable for a long, long time."
 

--- a/RICE/localization/polish/rice_siwa_l_polish.yml
+++ b/RICE/localization/polish/rice_siwa_l_polish.yml
@@ -68,7 +68,6 @@
  RICE_siwa_kharshif_structures_decision_desc:0 "Time and time again, the effectiveness of [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] as a construction material is proven. However, these traditional building materials from [GetTitleByKey('b_siwa').GetNameNoTier] could always use some maintenance."
  RICE_siwa_kharshif_structures_decision_effect_tooltip_1:1 "xxxxx"
  RICE_siwa_kharshif_structures_decision_confirm:0 "Let's get to work!"
- RICE_siwa_kharshif_structures_decision_context_tooltip:0 "#emphasis Historical Context:#! $KHARSHIF_GLOSS$"
  RICE_siwa_kharshif_modifier:0 "Maintaining Kharshif Structures"
  RICE_siwa_kharshif_modifier_desc:0 "Local rulers have dedicated resources to ensure that the [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] blocks of Siwa Oasis' structures will continue to be viable for a long, long time."
 

--- a/RICE/localization/russian/rice_siwa_l_russian.yml
+++ b/RICE/localization/russian/rice_siwa_l_russian.yml
@@ -68,7 +68,6 @@
  RICE_siwa_kharshif_structures_decision_desc:0 "Time and time again, the effectiveness of [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] as a construction material is proven. However, these traditional building materials from [GetTitleByKey('b_siwa').GetNameNoTier] could always use some maintenance."
  RICE_siwa_kharshif_structures_decision_effect_tooltip_1:1 "xxxxx"
  RICE_siwa_kharshif_structures_decision_confirm:0 "Let's get to work!"
- RICE_siwa_kharshif_structures_decision_context_tooltip:0 "#emphasis Historical Context:#! $KHARSHIF_GLOSS$"
  RICE_siwa_kharshif_modifier:0 "Maintaining Kharshif Structures"
  RICE_siwa_kharshif_modifier_desc:0 "Local rulers have dedicated resources to ensure that the [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] blocks of Siwa Oasis' structures will continue to be viable for a long, long time."
 

--- a/RICE/localization/spanish/rice_siwa_l_spanish.yml
+++ b/RICE/localization/spanish/rice_siwa_l_spanish.yml
@@ -68,7 +68,6 @@ RICE_siwa_kharshif_structures_decision_tooltip:0 "Los bloques de [Glossary( 'Kha
 RICE_siwa_kharshif_structures_decision_desc:0 "Una y otra vez, la eficacia del [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] como material de construcción está probada. Sin embargo, estos materiales de construcción tradicionales de [GetTitleByKey('b_siwa').GetNameNoTier] siempre podrían usar algo de mantenimiento."
 RICE_siwa_kharshif_structures_decision_effect_tooltip_1:1 "xxxxx"
 RICE_siwa_kharshif_structures_decision_confirm:0 "¡Pongámonos a trabajar!"
-RICE_siwa_kharshif_structures_decision_context_tooltip:0 "#emphasis Contexto histórico:#! $KHARSHIF_GLOSS$"
 RICE_siwa_kharshif_modifier:0 "Manteniendo Estructuras de Kharshif"
 RICE_siwa_kharshif_modifier_desc:0 "Los gobernantes locales han dedicado recursos para asegurar que los bloques de [Glossary( 'Kharshif', 'KHARSHIF_GLOSS' )] de las estructuras del Oasis de Siwa sigan siendo viables por mucho, mucho tiempo."
 


### PR DESCRIPTION
…uctures decision

The historical context in decision's effects is no longer needed as it is already accessible within the gloss tooltip in the decision description