### PR TITLE
fix: duplicate lic string in nubian content

### DIFF
--- a/RICE/localization/english/rice_nubia_l_english.yml
+++ b/RICE/localization/english/rice_nubia_l_english.yml
@@ -233,7 +233,7 @@
  #Eikkir:0 "Eikkir"
  dynn_RICE_nubia_ashkeit:0 "Ashkeit"
  RICE_every_courtier_prefers_byzantine_clothing:0 "Every [courtier|E] that prefers Byzantine-influenced clothing"
- RICE_nubia_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
+ RICE_every_courtier_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
 
  # Custom Localization 
  RICE_saint_catherine_ashtiname_of_muhammad:0 "Ashtiname of Muhammad"

--- a/RICE/localization/french/rice_nubia_l_french.yml
+++ b/RICE/localization/french/rice_nubia_l_french.yml
@@ -233,7 +233,7 @@
  #Eikkir:0 "Eikkir"
  dynn_RICE_nubia_ashkeit:0 "Ashkeit"
  RICE_every_courtier_prefers_byzantine_clothing:0 "Chaque [courtier|El] qui préfère les vêtements d'influence byzantine"
- RICE_nubia_prefers_indigenous_clothing:0 "Chaque [courtier|El] qui préfère les vêtements d'influence africaine"
+ RICE_every_courtier_prefers_indigenous_clothing:0 "Chaque [courtier|El] qui préfère les vêtements d'influence africaine"
 
  # Custom Localization 
  RICE_saint_catherine_ashtiname_of_muhammad:0 "Ashtiname de Mahomet"

--- a/RICE/localization/german/rice_nubia_l_german.yml
+++ b/RICE/localization/german/rice_nubia_l_german.yml
@@ -233,7 +233,7 @@
  #Eikkir:0 "Eikkir"
  dynn_RICE_nubia_ashkeit:0 "Ashkeit"
  RICE_every_courtier_prefers_byzantine_clothing:0 "Every [courtier|E] that prefers Byzantine-influenced clothing"
- RICE_nubia_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
+ RICE_every_courtier_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
 
  # Custom Localization 
  RICE_saint_catherine_ashtiname_of_muhammad:0 "Ashtiname of Muhammad"

--- a/RICE/localization/japanese/rice_nubia_l_japanese.yml
+++ b/RICE/localization/japanese/rice_nubia_l_japanese.yml
@@ -233,7 +233,7 @@
  #Eikkir:0 "Eikkir"
  dynn_RICE_nubia_ashkeit:0 "Ashkeit"
  RICE_every_courtier_prefers_byzantine_clothing:0 "Every [courtier|E] that prefers Byzantine-influenced clothing"
- RICE_nubia_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
+ RICE_every_courtier_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
 
  # Custom Localization 
  RICE_saint_catherine_ashtiname_of_muhammad:0 "Ashtiname of Muhammad"

--- a/RICE/localization/polish/rice_nubia_l_polish.yml
+++ b/RICE/localization/polish/rice_nubia_l_polish.yml
@@ -233,7 +233,7 @@
  #Eikkir:0 "Eikkir"
  dynn_RICE_nubia_ashkeit:0 "Ashkeit"
  RICE_every_courtier_prefers_byzantine_clothing:0 "Every [courtier|E] that prefers Byzantine-influenced clothing"
- RICE_nubia_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
+ RICE_every_courtier_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
 
  # Custom Localization 
  RICE_saint_catherine_ashtiname_of_muhammad:0 "Ashtiname of Muhammad"

--- a/RICE/localization/russian/rice_nubia_l_russian.yml
+++ b/RICE/localization/russian/rice_nubia_l_russian.yml
@@ -233,7 +233,7 @@
  #Eikkir:0 "Eikkir"
  dynn_RICE_nubia_ashkeit:0 "Ashkeit"
  RICE_every_courtier_prefers_byzantine_clothing:0 "Every [courtier|E] that prefers Byzantine-influenced clothing"
- RICE_nubia_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
+ RICE_every_courtier_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
 
  # Custom Localization 
  RICE_saint_catherine_ashtiname_of_muhammad:0 "Ashtiname of Muhammad"

--- a/RICE/localization/spanish/rice_nubia_l_spanish.yml
+++ b/RICE/localization/spanish/rice_nubia_l_spanish.yml
@@ -233,7 +233,7 @@ RICE_baqt_happened_interface_message_long:0 "[actor.GetTitledFirstName] y [recip
  #Eikkir:0 "Eikkir"
  dynn_RICE_nubia_ashkeit:0 "Ashkeit"
  RICE_every_courtier_prefers_byzantine_clothing:0 "Every [courtier|E] that prefers Byzantine-influenced clothing"
- RICE_nubia_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
+ RICE_every_courtier_prefers_indigenous_clothing:0 "Every [courtier|E] that prefers African-influenced clothing"
 
  # Custom Localization 
  RICE_saint_catherine_ashtiname_of_muhammad:0 "Ashtiname de Muhammad"


### PR DESCRIPTION
`RICE_nubia_prefers_indigenous_clothing` is defined twice in the loc files. Possibly a copy/paste error, as the event seems to use `RICE_every_courtier_prefers_indigenous_clothing` for this case